### PR TITLE
Potential fix for code scanning alert no. 17: Client-side cross-site scripting

### DIFF
--- a/http/default/query.js
+++ b/http/default/query.js
@@ -1,3 +1,15 @@
+/**
+ * Escape a string for safe insertion into HTML context.
+ */
+function escapeHTML(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 var params      = getQueryParams();
 var server_url  = window.location.protocol + "//"
                       + window.location.hostname
@@ -121,9 +133,9 @@ function execute_query() {
                 var table = '<table>';
                 for (var key in msg[0]) {
                     table += '<tr><td><a href="?num_queries=1&' +
-                        '0.field=' + field + '&' +
-                        '0.op=eq&0.key=' + key + '">' + key + '</a></td>' +
-                        '<td>' + msg[0][key] + '</td></tr>';
+                        '0.field=' + escapeHTML(field) + '&' +
+                        '0.op=eq&0.key=' + encodeURIComponent(key) + '">' + escapeHTML(key) + '</a></td>' +
+                        '<td>' + escapeHTML(String(msg[0][key])) + '</td></tr>';
                 }
                 table += '</table>';
                 document.getElementById("output").innerHTML = table;


### PR DESCRIPTION
Potential fix for [https://github.com/datapoke/tachikoma/security/code-scanning/17](https://github.com/datapoke/tachikoma/security/code-scanning/17)

To fix this DOM-based XSS vulnerability, all user-controlled data interpolated into HTML (especially when using `innerHTML`) must be properly escaped or sanitized. The best way to do this is to encode any user-provided values for HTML context before inserting them into the DOM. In this case, the `field`, `key`, and `msg[0][key]` variables are all potentially tainted and should be escaped.

The fix involves:
- Creating a helper function to HTML-escape strings (e.g., replacing `<`, `>`, `&`, `"`, `'` with their HTML entities).
- Using this function to escape `field`, `key`, and `msg[0][key]` before interpolating them into the HTML string in the `execute_query` function.
- The helper function can be defined at the top of the file or near its first use.

No external dependencies are required; a simple escape function can be implemented inline.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
